### PR TITLE
Make LogoMark rounded in header and footer

### DIFF
--- a/app/components/SiteHeader.tsx
+++ b/app/components/SiteHeader.tsx
@@ -23,7 +23,7 @@ export function SiteHeader() {
           className="mr-auto inline-flex items-center gap-3 text-xl font-bold text-[color:var(--foreground)] transition hover:text-[color:var(--accent-primary)]"
           aria-label="SudoStake home"
         >
-          <LogoMark size={34} className="h-9 w-9 flex-none" />
+          <LogoMark size={34} className="h-9 w-9 flex-none rounded-full" />
           <span>SudoStake</span>
         </a>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -75,7 +75,7 @@ export default function Home() {
 
       <footer className="footer-panel py-8 text-center text-xs text-[color:var(--text-secondary)]">
         <div className="mx-auto flex w-full max-w-6xl flex-col items-center gap-2 px-5 sm:px-6 lg:px-8">
-          <LogoMark size={36} className="h-10 w-10" ariaLabel="SudoStake mark" />
+          <LogoMark size={36} className="h-10 w-10 rounded-full" ariaLabel="SudoStake mark" />
           <span className="font-medium text-[color:var(--text-secondary)]">© 2026 SudoStake</span>
         </div>
       </footer>


### PR DESCRIPTION
Add the Tailwind `rounded-full` class to LogoMark instances in SiteHeader.tsx and app/page.tsx so the site logo displays with a rounded avatar-style appearance for visual consistency between header and footer.