### PR TITLE
Tighten UI spacing and add network logos

### DIFF
--- a/app/components/HeroSection.tsx
+++ b/app/components/HeroSection.tsx
@@ -8,16 +8,16 @@ export function HeroSection() {
   return (
     <section id="how-it-works" className="w-full py-12 sm:py-14 lg:py-16">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 sm:gap-9">
-        <h1 className="max-w-5xl text-pretty text-[2.75rem] font-bold leading-[1.02] tracking-[-0.02em] text-[color:var(--text-primary)] sm:text-[3.7rem] lg:text-[4.9rem]">
+        <h1 className="max-w-5xl text-pretty text-[2.15rem] font-bold leading-[1.04] tracking-[-0.02em] text-[color:var(--text-primary)] sm:text-[2.95rem] lg:text-[3.75rem]">
           Earn from staking.
           <span className="block">Trade anytime.</span>
         </h1>
 
-        <div className="hero-panel rounded-3xl px-6 py-6 sm:px-8 sm:py-8">
-          <h2 className="text-xl font-semibold text-[color:var(--text-primary)] sm:text-2xl">
+        <div className="hero-panel rounded-2xl px-5 py-5 sm:px-7 sm:py-7">
+          <h2 className="text-lg font-semibold text-[color:var(--text-primary)] sm:text-xl">
             Start in 3 quick steps
           </h2>
-          <ul className="mt-4 list-decimal space-y-3 pl-5 text-base leading-relaxed text-[color:var(--text-secondary)] sm:text-lg">
+          <ul className="mt-3 list-decimal space-y-2.5 pl-5 text-sm leading-relaxed text-[color:var(--text-secondary)] sm:text-base">
             {quickStartSteps.map((step) => (
               <li key={step}>{step}</li>
             ))}
@@ -27,7 +27,7 @@ export function HeroSection() {
         <div className="flex">
           <a
             href="#apps"
-            className="btn-primary inline-flex w-full items-center justify-center rounded-full px-8 py-3.5 text-base font-semibold transition sm:w-auto"
+            className="btn-primary inline-flex w-full items-center justify-center rounded-full px-7 py-3 text-sm font-semibold transition sm:w-auto"
           >
             Start now: choose network
           </a>

--- a/app/components/NetworkSection.tsx
+++ b/app/components/NetworkSection.tsx
@@ -1,22 +1,30 @@
+import Image from "next/image";
+
 type Network = {
   name: string;
   href: string;
   description: string;
   availability: string;
+  logoSrc: string;
+  logoAlt: string;
 };
 
 const networks: Network[] = [
   {
-    name: "Cosmos dApp",
+    name: "Cosmos",
     href: "https://cosmos.sudostake.com",
     description: "Stake-backed borrowing and lending on Cosmos mainnet.",
     availability: "Mainnet",
+    logoSrc: "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg",
+    logoAlt: "Cosmos logo",
   },
   {
-    name: "NEAR dApp",
+    name: "NEAR",
     href: "https://near.sudostake.com",
-    description: "Stake-backed borrowing and lending flow on NEAR testnet.",
+    description: "Stake-backed borrowing and lending on NEAR testnet.",
     availability: "Testnet",
+    logoSrc: "https://pages.near.org/wp-content/uploads/2021/09/brand-icon-300x300.png",
+    logoAlt: "NEAR logo",
   },
 ];
 
@@ -31,7 +39,7 @@ export function NetworkSection() {
           </p>
         </div>
 
-        <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <ul className="grid grid-cols-1 gap-5 sm:grid-cols-2">
           {networks.map((network) => (
             <li key={network.name} className="h-full">
               <a
@@ -39,18 +47,23 @@ export function NetworkSection() {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`Open ${network.name} (${network.availability})`}
-                className="flex h-full flex-col gap-5 rounded-3xl surface-card px-6 py-7 text-left text-[color:var(--text-primary)] transition hover:border-[color:var(--accent-primary)] sm:px-7"
+                className="flex h-full flex-col gap-4 rounded-2xl surface-card px-5 py-6 text-left text-[color:var(--text-primary)] transition hover:border-[color:var(--accent-primary)] sm:px-6"
               >
-                <div className="flex flex-col gap-3">
-                  <h3 className="text-[1.75rem] font-semibold leading-tight text-[color:var(--text-primary)] sm:text-[1.95rem]">
-                    {network.name}
-                  </h3>
-                  <p className="text-base leading-relaxed text-[color:var(--text-secondary)]">
-                    {network.description}
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-3">
+                    <span className="inline-flex rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-muted)] p-2">
+                      <Image src={network.logoSrc} alt={network.logoAlt} width={28} height={28} className="h-7 w-7" />
+                    </span>
+                    <h3 className="text-[1.25rem] font-semibold leading-tight text-[color:var(--text-primary)] sm:text-[1.35rem]">
+                      {network.name}
+                    </h3>
+                  </div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[color:var(--text-tertiary)]">
+                    {network.availability}
                   </p>
-                  <p className="text-sm font-medium text-[color:var(--text-tertiary)]">{network.availability}</p>
                 </div>
-                <span className="mt-auto text-base font-semibold text-[color:var(--accent-primary)]">
+                <p className="text-sm leading-relaxed text-[color:var(--text-secondary)]">{network.description}</p>
+                <span className="mt-auto text-sm font-semibold text-[color:var(--accent-primary)]">
                   Open app
                 </span>
               </a>

--- a/app/components/SiteHeader.tsx
+++ b/app/components/SiteHeader.tsx
@@ -20,7 +20,7 @@ export function SiteHeader() {
       <div className="flex w-full items-center gap-3 px-5 py-3 sm:px-6 lg:px-8">
         <a
           href="#top"
-          className="mr-auto inline-flex items-center gap-3 text-xl font-bold text-[color:var(--foreground)] transition hover:text-[color:var(--accent-primary)]"
+          className="mr-auto inline-flex items-center gap-3 text-lg font-bold text-[color:var(--foreground)] transition hover:text-[color:var(--accent-primary)] sm:text-xl"
           aria-label="SudoStake home"
         >
           <LogoMark size={34} className="h-9 w-9 flex-none rounded-full" />

--- a/app/globals.css
+++ b/app/globals.css
@@ -87,7 +87,7 @@
     background: var(--background);
     color: var(--foreground);
     font-family: var(--font-jakarta-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    line-height: 1.55;
+    line-height: 1.5;
   }
 
   a {
@@ -202,17 +202,17 @@
   }
 
   .section-heading {
-    font-size: clamp(2.1rem, 3.6vw, 2.9rem);
+    font-size: clamp(1.75rem, 3.1vw, 2.35rem);
     font-weight: 600;
     letter-spacing: -0.015em;
-    line-height: 1.12;
+    line-height: 1.16;
   }
 
   .section-subtitle {
-    font-size: 1.05rem;
-    line-height: 1.7;
+    font-size: 0.98rem;
+    line-height: 1.6;
     color: var(--text-secondary);
-    max-width: 46rem;
+    max-width: 42rem;
   }
 
   .bg-surface-primary {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,11 +46,11 @@ function ResourcesSection() {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`Open ${name} in a new tab`}
-                className="flex h-full flex-col gap-4 rounded-3xl surface-card px-6 py-7 text-left text-[color:var(--text-primary)] transition hover:border-[color:var(--accent-primary)]"
+                className="flex h-full flex-col gap-3 rounded-2xl surface-card px-5 py-6 text-left text-[color:var(--text-primary)] transition hover:border-[color:var(--accent-primary)]"
               >
-                <span className="text-xl font-semibold text-[color:var(--text-primary)]">{name}</span>
-                <p className="text-base leading-relaxed text-[color:var(--text-secondary)]">{description}</p>
-                <span className="inline-flex items-center gap-2 text-base font-semibold text-[color:var(--accent-primary)]">
+                <span className="text-lg font-semibold text-[color:var(--text-primary)]">{name}</span>
+                <p className="text-sm leading-relaxed text-[color:var(--text-secondary)]">{description}</p>
+                <span className="inline-flex items-center gap-2 text-sm font-semibold text-[color:var(--accent-primary)]">
                   Visit
                 </span>
               </a>

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "raw.githubusercontent.com",
+      },
+      {
+        protocol: "https",
+        hostname: "pages.near.org",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Adjust visual scale and spacing across the site: reduce heading sizes, tighten paddings, and switch several rounded-3xl cards to rounded-2xl for a more compact layout. Update HeroSection and resource cards to use smaller typography and spacing. Enhance NetworkSection by adding logo fields, importing next/image, displaying logo icons with availability badges, and simplifying network names/descriptions. Update SiteHeader responsive text sizing and tweak global typography (line-height, section-heading/subtitle sizes and max-width). Add next.config image remotePatterns for raw.githubusercontent.com and pages.near.org to allow the external network logos to load.