### PR TITLE
Simplify header nav and remove CTAs

### DIFF
--- a/app/components/HeroSection.tsx
+++ b/app/components/HeroSection.tsx
@@ -24,14 +24,6 @@ export function HeroSection() {
           </ul>
         </div>
 
-        <div className="flex">
-          <a
-            href="#apps"
-            className="btn-primary inline-flex w-full items-center justify-center rounded-full px-7 py-3 text-sm font-semibold transition sm:w-auto"
-          >
-            Start now: choose network
-          </a>
-        </div>
       </div>
     </section>
   );

--- a/app/components/SiteHeader.tsx
+++ b/app/components/SiteHeader.tsx
@@ -3,15 +3,11 @@ import { LogoMark } from "./LogoMark";
 type NavLink = {
   label: string;
   href: string;
-  external?: boolean;
-  ariaLabel?: string;
 };
 
 const navLinks: NavLink[] = [
-  { label: "Overview", href: "#how-it-works" },
   { label: "Apps", href: "#apps" },
   { label: "Resources", href: "#resources" },
-  { label: "GitHub", href: "https://github.com/sudostake", external: true },
 ];
 
 export function SiteHeader() {
@@ -27,33 +23,17 @@ export function SiteHeader() {
           <span>SudoStake</span>
         </a>
 
-        <nav className="hidden items-center gap-3 text-sm font-medium text-[color:var(--text-secondary)] sm:flex">
-          {navLinks.map(({ label, href, external, ariaLabel }) => (
+        <nav className="flex items-center gap-3 text-xs font-medium text-[color:var(--text-secondary)] sm:gap-4 sm:text-sm">
+          {navLinks.map(({ label, href }) => (
             <a
               key={href}
               href={href}
               className="transition hover:text-[color:var(--accent-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[color:var(--accent-primary)]"
-              target={external ? "_blank" : undefined}
-              rel={external ? "noopener noreferrer" : undefined}
-              aria-label={ariaLabel}
             >
               {label}
             </a>
           ))}
-          <a
-            href="#apps"
-            className="btn-primary inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold transition"
-          >
-            Open app
-          </a>
         </nav>
-
-        <a
-          href="#apps"
-          className="btn-primary inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold transition sm:hidden"
-        >
-          Open app
-        </a>
       </div>
     </header>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,9 +50,6 @@ function ResourcesSection() {
               >
                 <span className="text-lg font-semibold text-[color:var(--text-primary)]">{name}</span>
                 <p className="text-sm leading-relaxed text-[color:var(--text-secondary)]">{description}</p>
-                <span className="inline-flex items-center gap-2 text-sm font-semibold text-[color:var(--accent-primary)]">
-                  Visit
-                </span>
               </a>
             </li>
           ))}


### PR DESCRIPTION
Remove redundant call-to-action buttons and simplify the site header navigation. HeroSection: remove the "Start now: choose network" CTA. SiteHeader: remove Overview and GitHub links, drop external/aria props, adjust nav sizing and spacing, and remove the "Open app" buttons (desktop and mobile). page.tsx: remove the inline "Visit" label from resource items. These changes declutter the header and resource list and standardize the nav markup/styles.