### PR TITLE
Add vault flow UI, network/resource summaries

### DIFF
--- a/app/components/HeroSection.tsx
+++ b/app/components/HeroSection.tsx
@@ -1,11 +1,50 @@
+type FlowStep = {
+  title: string;
+  detail: string;
+};
+
+const flowSteps: FlowStep[] = [
+  {
+    title: "Stake",
+    detail: "Stake your L1 assets and keep validator rewards active.",
+  },
+  {
+    title: "Vault",
+    detail: "Your vault smart contract allows users or agents to use staked assets as collateral.",
+  },
+  {
+    title: "Borrow",
+    detail: "Access USDC liquidity on demand without exiting your stake.",
+  },
+];
+
 export function HeroSection() {
   return (
     <section id="how-it-works" className="w-full py-10 sm:py-12 lg:py-14">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-7 sm:gap-8">
-        <h1 className="pixel-hero max-w-5xl text-[1rem] font-normal text-[color:var(--text-primary)] sm:text-[1.32rem] lg:text-[1.62rem]">
-          Earn from staking.
-          <span className="block">Trade anytime.</span>
-        </h1>
+      <div className="mx-auto grid w-full max-w-6xl gap-8 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] xl:items-center">
+        <div className="flex flex-col gap-5">
+          <span className="pixel-chip w-fit text-[color:var(--text-secondary)]">Vault-native collateral</span>
+          <h1 className="pixel-hero max-w-5xl text-[1rem] font-normal text-[color:var(--text-primary)] sm:text-[1.32rem] lg:text-[1.62rem]">
+            Use staked L1 assets
+            <span className="block">as collateral for USDC.</span>
+          </h1>
+          <p className="max-w-3xl text-[0.86rem] text-[color:var(--text-secondary)] sm:text-[0.94rem]">
+            SudoStake vault smart contracts allow users or agents to use staked L1 assets as collateral to access USDC on demand.
+          </p>
+        </div>
+
+        <div className="illustration-shell px-4 py-5 sm:px-5 sm:py-6">
+          <p className="pixel-heading text-[0.6rem] text-[color:var(--text-secondary)]">How it works</p>
+          <ol className="story-rail mt-4">
+            {flowSteps.map((step, index) => (
+              <li key={step.title} className="story-step">
+                <span className="story-index">{String(index + 1).padStart(2, "0")}</span>
+                <h3 className="story-title">{step.title}</h3>
+                <p className="story-copy">{step.detail}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
       </div>
     </section>
   );

--- a/app/components/NetworkSection.tsx
+++ b/app/components/NetworkSection.tsx
@@ -6,6 +6,8 @@ type Network = {
   availability: string;
   logoSrc: string;
   logoAlt: string;
+  summary: string;
+  tokenTag: string;
 };
 
 const networks: Network[] = [
@@ -15,6 +17,8 @@ const networks: Network[] = [
     availability: "Mainnet",
     logoSrc: "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg",
     logoAlt: "Cosmos logo",
+    summary: "Use staked ATOM in your vault as collateral to access USDC.",
+    tokenTag: "ATOM",
   },
   {
     name: "NEAR",
@@ -22,6 +26,8 @@ const networks: Network[] = [
     availability: "Testnet",
     logoSrc: "https://pages.near.org/wp-content/uploads/2021/09/brand-icon-300x300.png",
     logoAlt: "NEAR logo",
+    summary: "Testnet vault flow using staked NEAR as collateral for USDC.",
+    tokenTag: "NEAR",
   },
 ];
 
@@ -42,15 +48,23 @@ export function NetworkSection() {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`Go to ${network.name} (${network.availability})`}
-                className="group pixel-card surface-card flex h-full items-center justify-between gap-4 px-4 py-5 text-left text-[color:var(--text-primary)] sm:px-5"
+                className="group pixel-card surface-card flex h-full min-w-0 flex-col gap-3 px-4 py-5 text-left text-[color:var(--text-primary)] sm:px-5 lg:flex-row lg:items-start lg:justify-between"
               >
-                <div className="flex items-center gap-3">
-                  <Image src={network.logoSrc} alt={network.logoAlt} width={28} height={28} className="h-7 w-7 flex-none" />
-                  <h3 className="pixel-heading text-[0.8rem] text-[color:var(--text-primary)] sm:text-[0.88rem]">
-                    {network.name}
-                  </h3>
+                <div className="flex min-w-0 items-start gap-3">
+                  <span className="network-mark">
+                    <Image src={network.logoSrc} alt={network.logoAlt} width={28} height={28} className="h-7 w-7 flex-none" />
+                  </span>
+                  <div className="flex min-w-0 flex-col gap-1">
+                    <h3 className="pixel-heading text-[0.8rem] text-[color:var(--text-primary)] sm:text-[0.88rem]">
+                      {network.name}
+                    </h3>
+                    <p className="break-words text-[0.7rem] leading-[1.3] text-[color:var(--text-secondary)] sm:text-[0.76rem]">
+                      {network.summary}
+                    </p>
+                  </div>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+                  <p className="pixel-chip text-[color:var(--text-secondary)]">{network.tokenTag}</p>
                   <p className="pixel-chip text-[color:var(--text-tertiary)]">{network.availability}</p>
                   <span className="pixel-heading text-[0.64rem] text-[color:var(--accent-primary)] transition-transform group-hover:translate-x-0.5">
                     -&gt;

--- a/app/globals.css
+++ b/app/globals.css
@@ -106,6 +106,16 @@
 
   body {
     background:
+      radial-gradient(
+          circle at 10% 12%,
+          color-mix(in oklab, var(--accent-primary) 11%, transparent) 0,
+          transparent 34%
+        ),
+      radial-gradient(
+          circle at 90% 8%,
+          color-mix(in oklab, var(--accent-primary) 9%, transparent) 0,
+          transparent 30%
+        ),
       linear-gradient(
           90deg,
           color-mix(in oklab, var(--background-strong) 76%, transparent) 1px,
@@ -120,8 +130,8 @@
       linear-gradient(180deg, var(--background), var(--background-strong));
     color: var(--foreground);
     font-family: var(--font-pixel-body), "Courier New", Courier, monospace;
-    font-size: clamp(1.28rem, 1.95vw, 1.52rem);
-    line-height: 1.34;
+    font-size: clamp(1rem, 1.15vw, 1.16rem);
+    line-height: 1.4;
     letter-spacing: 0.02em;
     -webkit-font-smoothing: none;
     text-rendering: optimizeSpeed;
@@ -320,6 +330,100 @@
     background: var(--surface-card-bg);
     border: 2px solid var(--panel-border);
     box-shadow: var(--pixel-shadow);
+  }
+
+  .illustration-shell {
+    border: 2px solid var(--panel-border);
+    background:
+      linear-gradient(
+          135deg,
+          color-mix(in oklab, var(--surface) 88%, var(--accent-primary) 12%),
+          color-mix(in oklab, var(--surface-muted) 90%, transparent)
+        ),
+      repeating-linear-gradient(
+          90deg,
+          color-mix(in oklab, var(--background-strong) 42%, transparent),
+          color-mix(in oklab, var(--background-strong) 42%, transparent) 1px,
+          transparent 1px,
+          transparent 10px
+        );
+    box-shadow: var(--pixel-shadow-lg);
+  }
+
+  .story-rail {
+    display: grid;
+    gap: 0.8rem;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  }
+
+  .story-step {
+    border: 2px solid var(--panel-border);
+    background: color-mix(in oklab, var(--surface) 86%, transparent);
+    padding: 0.6rem 0.7rem 0.72rem;
+    min-height: 0;
+  }
+
+  .story-index {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+    border: 2px solid var(--panel-border);
+    background: color-mix(in oklab, var(--surface-muted) 86%, transparent);
+    padding: 0.08rem 0.4rem;
+    font-family: var(--font-pixel-display), "Courier New", Courier, monospace;
+    font-size: 0.52rem;
+    line-height: 1.3;
+    color: var(--text-secondary);
+  }
+
+  .story-title {
+    margin-top: 0.46rem;
+    font-family: var(--font-pixel-display), "Courier New", Courier, monospace;
+    font-size: 0.66rem;
+    letter-spacing: 0.05em;
+    line-height: 1.3;
+    text-transform: uppercase;
+    color: var(--text-primary);
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .story-copy {
+    margin-top: 0.34rem;
+    font-size: 0.64rem;
+    line-height: 1.3;
+    color: var(--text-secondary);
+    letter-spacing: 0.02em;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .network-mark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border: 2px solid var(--panel-border);
+    background: color-mix(in oklab, var(--surface-muted) 88%, transparent);
+    box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--surface) 58%, transparent);
+    flex: none;
+  }
+
+  .resource-mark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.25rem;
+    border: 2px solid var(--panel-border);
+    background: color-mix(in oklab, var(--surface-muted) 90%, transparent);
+    padding: 0.13rem 0.5rem;
+    font-family: var(--font-pixel-display), "Courier New", Courier, monospace;
+    font-size: 0.58rem;
+    line-height: 1.2;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
   }
 
   .nav-panel {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,19 +20,19 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "SudoStake | Stake-Backed Liquidity",
+  title: "SudoStake | Staked Assets as Collateral",
   description:
-    "Borrow or lend without unstaking. Unlock USDC liquidity while validator rewards keep compounding.",
+    "SudoStake vault smart contracts allow users or agents to use staked L1 assets as collateral so they can access USDC liquidity anytime while rewards keep compounding.",
   openGraph: {
-    title: "SudoStake | Stake-Backed Liquidity",
+    title: "SudoStake | Staked Assets as Collateral",
     description:
-      "Borrow or lend without unstaking. Unlock USDC liquidity while validator rewards keep compounding.",
+      "SudoStake vault smart contracts allow users or agents to use staked L1 assets as collateral so they can access USDC liquidity anytime while rewards keep compounding.",
   },
   twitter: {
     card: "summary_large_image",
-    title: "SudoStake | Stake-Backed Liquidity",
+    title: "SudoStake | Staked Assets as Collateral",
     description:
-      "Borrow or lend without unstaking. Unlock USDC liquidity while validator rewards keep compounding.",
+      "SudoStake vault smart contracts allow users or agents to use staked L1 assets as collateral so they can access USDC liquidity anytime while rewards keep compounding.",
   },
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ type ResourceLink = {
   name: string;
   href: string;
   tag: string;
+  description: string;
 };
 
 const resources: ResourceLink[] = [
@@ -14,16 +15,19 @@ const resources: ResourceLink[] = [
     name: "GitHub",
     href: "https://github.com/sudostake",
     tag: "GH",
+    description: "Open-source repos and release notes.",
   },
   {
     name: "Telegram",
     href: "https://t.me/sudostake",
     tag: "TG",
+    description: "Community chat and support updates.",
   },
   {
-    name: "X (Twitter)",
+    name: "X",
     href: "https://x.com/sudostake",
     tag: "X",
+    description: "Product updates and launch announcements.",
   },
 ];
 
@@ -33,25 +37,33 @@ function ResourcesSection() {
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
         <div className="flex flex-col gap-3">
           <h2 className="section-heading text-[color:var(--text-primary)]">Resources</h2>
+          <p className="max-w-3xl text-[0.8rem] text-[color:var(--text-secondary)] sm:text-[0.88rem]">
+            Follow releases, ecosystem news, and community updates.
+          </p>
         </div>
 
         <ul className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          {resources.map(({ name, href, tag }) => (
+          {resources.map(({ name, href, tag, description }) => (
             <li key={href} className="h-full">
               <a
                 href={href}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`Go to ${name} in a new tab`}
-                className="group pixel-card surface-card flex h-full items-center justify-between gap-4 px-4 py-5 text-left text-[color:var(--text-primary)]"
+                className="group pixel-card surface-card flex h-full min-w-0 flex-col gap-3 px-4 py-5 text-left text-[color:var(--text-primary)] sm:gap-4"
               >
-                <span className="flex items-center gap-3">
-                  <span className="pixel-chip min-w-[2.1rem] justify-center text-[color:var(--text-secondary)]">
+                <span className="flex min-w-0 items-start gap-3">
+                  <span className="resource-mark text-[color:var(--text-secondary)]">
                     {tag}
                   </span>
-                  <span className="pixel-heading text-[0.72rem] text-[color:var(--text-primary)]">{name}</span>
+                  <span className="flex min-w-0 flex-col gap-1">
+                    <span className="pixel-heading text-[0.72rem] text-[color:var(--text-primary)]">{name}</span>
+                    <span className="break-words text-[0.66rem] leading-[1.3] text-[color:var(--text-secondary)] sm:text-[0.72rem]">
+                      {description}
+                    </span>
+                  </span>
                 </span>
-                <span className="pixel-heading text-[0.62rem] text-[color:var(--accent-primary)] transition-transform group-hover:translate-x-0.5">
+                <span className="pixel-heading self-end text-[0.62rem] text-[color:var(--accent-primary)] transition-transform group-hover:translate-x-0.5">
                   -&gt;
                 </span>
               </a>


### PR DESCRIPTION
Introduce a structured hero flow and richer network/resource cards: add FlowStep type and flowSteps array, refactor HeroSection to a two-column grid with an illustrated "How it works" rail. Extend NetworkSection and Resource links with summary/tokenTag/description fields and update their card layouts to show summaries, token chips, and improved responsive styles. Add new CSS utilities (.illustration-shell, .story-rail, .story-step, .story-index, .story-title, .story-copy, .network-mark, .resource-mark) and adjust global typography/gradients. Also update site metadata titles/descriptions to emphasize "Staked Assets as Collateral."