### PR TITLE
Revamp hero copy and page layout/styles

### DIFF
--- a/app/components/landing/BorrowCurrencyHero.tsx
+++ b/app/components/landing/BorrowCurrencyHero.tsx
@@ -184,7 +184,9 @@ export function BorrowCurrencyHero({
 
   return (
     <div className="hero-copy">
-      <p className="hero-kicker">Stake, borrow, stay exposed.</p>
+      <p className="hero-kicker">
+        Use USYC or staked crypto vaults to borrow across Arc and L1 chains.
+      </p>
       <h1>
         Borrow{" "}
         <AnimatedCurrency
@@ -194,25 +196,12 @@ export function BorrowCurrencyHero({
           resetDurationMs={resetDurationMs}
           transition={transition}
         />{" "}
-        Without Unstaking
+        against vault collateral
       </h1>
       <p className="hero-lede">
-        Open a vault on a supported network, deposit your tokens, keep them
-        staked, and unlock liquidity from that collateral while rewards
-        continue to accrue.
+        Deposit USYC or staked crypto, keep exposure to the underlying asset,
+        and draw liquidity through x402, bridging, or teleportation rails.
       </p>
-      <div className="hero-support" aria-label="Supported borrow currencies">
-        <div className="support-group">
-          <span className="support-label">Borrow</span>
-          <div className="support-pills">
-            {availableCurrencies.map((currency) => (
-              <span key={currency} className="support-pill">
-                {currency}
-              </span>
-            ))}
-          </div>
-        </div>
-      </div>
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -106,46 +106,29 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
-    padding-block: 1rem;
+    gap: clamp(1.75rem, 5vw, 3.25rem);
+    padding-block: clamp(1.75rem, 5vw, 3.25rem);
   }
 
-  .panel {
-    margin: 0;
-    border: 1px solid var(--app-border-strong);
-    border-radius: 12px;
-    background: var(--app-surface);
-    color: CanvasText;
-    padding: 1rem;
-  }
-
-  .panel > legend {
-    padding-inline: 0.5rem;
-    color: var(--app-legend);
-    font-size: 0.95rem;
-    font-weight: 600;
-  }
-
-  .panel--hero {
-    min-height: clamp(14rem, 28vh, 18rem);
-    background:
-      linear-gradient(
-        135deg,
-        var(--app-surface-strong),
-        color-mix(in srgb, var(--app-surface) 88%, CanvasText 12%)
-      );
+  .hero-section {
+    min-height: clamp(16rem, 36vh, 24rem);
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--app-border);
+    padding-bottom: clamp(2rem, 6vw, 4rem);
   }
 
   .hero-copy {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 
   .hero-copy h1 {
     margin: 0;
-    font-size: clamp(2rem, 5vw, 3.75rem);
-    line-height: 1.02;
+    max-width: 13ch;
+    font-size: clamp(2.25rem, 6vw, 4.5rem);
+    line-height: 0.98;
   }
 
   .hero-copy p {
@@ -155,51 +138,15 @@
 
   .hero-kicker {
     color: var(--app-muted);
-    font-size: 0.92rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
+    font-size: 1rem;
+    font-weight: 500;
+    letter-spacing: 0;
+    text-transform: none;
   }
 
   .hero-lede {
     font-size: 1.05rem;
-  }
-
-  .hero-support {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.875rem 1.25rem;
-  }
-
-  .support-group {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.625rem;
-  }
-
-  .support-label {
     color: var(--app-muted);
-    font-size: 0.92rem;
-    font-weight: 600;
-  }
-
-  .support-pills {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  .support-pill {
-    display: inline-flex;
-    align-items: center;
-    min-height: 2rem;
-    padding-inline: 0.75rem;
-    border: 1px solid var(--app-border);
-    border-radius: 999px;
-    background: var(--app-surface-strong);
-    font-size: 0.95rem;
-    font-weight: 600;
   }
 
   .currency-swap {
@@ -253,23 +200,41 @@
     animation: currency-swap-reset 220ms cubic-bezier(0.1, 0.92, 0.2, 1) both;
   }
 
-  .panel-item h3 {
+  .content-grid {
+    display: grid;
+    gap: clamp(2rem, 5vw, 3rem);
+  }
+
+  .content-section {
+    display: grid;
+    gap: 1rem;
+    align-content: start;
+  }
+
+  .content-section h2 {
+    margin: 0;
+    color: var(--app-muted);
+    font-size: 0.95rem;
+    font-weight: 600;
+  }
+
+  .content-item h3 {
     margin: 0 0 0.5rem;
     color: CanvasText;
     font-size: 1.125rem;
     line-height: 1.2;
   }
 
-  .panel-list {
+  .content-list {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 0.75rem;
+    border-top: 1px solid var(--app-border);
   }
 
-  .panel-list--networks {
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  .network-list {
+    gap: 0;
   }
 
   .network-summary-item {
@@ -288,31 +253,25 @@
     color: var(--app-muted);
   }
 
-  .panel-grid {
+  .content-item {
     display: grid;
-    gap: 1rem;
+    gap: 0.125rem;
+    border-bottom: 1px solid var(--app-border);
+    padding-block: 1rem;
   }
 
-  .panel-item {
-    border: 1px solid var(--app-border);
-    border-radius: 10px;
-    background: var(--app-surface-strong);
-    padding: 1rem;
-  }
-
-  .panel-item p {
+  .content-item p {
     margin: 0;
   }
 
-  .panel-item--network {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+  .network-item {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
     gap: 0.875rem;
   }
 
   .item-index {
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.25rem;
     color: var(--app-muted);
     font-weight: 600;
   }
@@ -380,7 +339,7 @@
 }
 
 @media (min-width: 900px) {
-  .panel-grid {
+  .content-grid {
     grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
   }
 }
@@ -400,6 +359,10 @@
 
   .hero-lede {
     font-size: 1rem;
+  }
+
+  .network-item {
+    grid-template-columns: 1fr;
   }
 
   .app-bar__row,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,18 +2,18 @@ import "./globals.css";
 import type { Metadata } from "next";
 
 const description =
-  "Keep supported assets staked and borrow stablecoins through SudoStake vaults.";
+  "Use USYC or staked crypto vaults to borrow crypto liquidity, USDC, EURC, and cNGN across Arc and supported L1 chains.";
 
 export const metadata: Metadata = {
-  title: "SudoStake | Borrow Stablecoins Without Unstaking",
+  title: "SudoStake | Vault-Backed Liquidity Across Arc and L1s",
   description,
   openGraph: {
-    title: "SudoStake | Borrow Stablecoins Without Unstaking",
+    title: "SudoStake | Vault-Backed Liquidity Across Arc and L1s",
     description,
   },
   twitter: {
     card: "summary_large_image",
-    title: "SudoStake | Borrow Stablecoins Without Unstaking",
+    title: "SudoStake | Vault-Backed Liquidity Across Arc and L1s",
     description,
   },
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,23 +20,23 @@ type SocialLink = {
   href: string;
 };
 
-const borrowCurrencies = ["USDC", "EURC", "USDT", "cNGN"];
+const borrowCurrencies = ["L1 tokens", "USDC", "EURC", "cNGN"];
 
 const steps: Step[] = [
   {
-    title: "Create a vault",
+    title: "Vault",
     description:
-      "Choose a supported network and open the vault for the asset you want to use.",
+      "Open a USYC vault on Arc or a staked crypto vault on a supported L1.",
   },
   {
-    title: "Deposit and stake",
+    title: "Fund",
     description:
-      "Deposit your tokens and keep the collateral staked while rewards continue accruing.",
+      "Move collateral in through x402, bridging, or teleportation.",
   },
   {
-    title: "Borrow stablecoins",
+    title: "Borrow",
     description:
-      "Draw against the position when you need liquidity without exiting your stake.",
+      "Access crypto liquidity, USDC, EURC, or cNGN against that vault.",
   },
 ];
 
@@ -44,21 +44,21 @@ const networks: Network[] = [
   {
     name: "NEAR",
     href: "https://near.sudostake.com",
-    description: "Use staked NEAR as collateral.",
+    description: "Use staked NEAR as collateral for stablecoin liquidity.",
     logoSrc: "/near-logo.png",
     logoAlt: "NEAR logo",
   },
   {
     name: "Archway",
     href: "https://cosmos.sudostake.com",
-    description: "Use staked ARCH as collateral.",
+    description: "Use staked ARCH as collateral for stablecoin liquidity.",
     logoSrc: "/archway-logo.svg",
     logoAlt: "Archway logo",
   },
   {
     name: "Chihuahua",
     href: "https://cosmos.sudostake.com",
-    description: "Use staked HUAHUA as collateral.",
+    description: "Use staked HUAHUA as collateral for stablecoin liquidity.",
     logoSrc: "/chihuahua-logo.svg",
     logoAlt: "Chihuahua logo",
   },
@@ -107,30 +107,29 @@ export default function Home() {
       </header>
 
       <main className="frame page-layout">
-        <fieldset className="panel panel--hero">
-          <legend>Overview</legend>
+        <section className="hero-section">
           <BorrowCurrencyHero currencies={borrowCurrencies} />
-        </fieldset>
+        </section>
 
-        <div className="panel-grid">
-          <fieldset className="panel">
-            <legend>How it works</legend>
-            <ol className="panel-list">
+        <div className="content-grid">
+          <section className="content-section" aria-labelledby="flow-title">
+            <h2 id="flow-title">Flow</h2>
+            <ol className="content-list">
               {steps.map((step, index) => (
-                <li key={step.title} className="panel-item">
+                <li key={step.title} className="content-item">
                   <p className="item-index">{index + 1}.</p>
                   <h3>{step.title}</h3>
                   <p className="muted-text">{step.description}</p>
                 </li>
               ))}
             </ol>
-          </fieldset>
+          </section>
 
-          <fieldset className="panel">
-            <legend>Supported networks</legend>
-            <ul className="panel-list panel-list--networks">
+          <section className="content-section" aria-labelledby="networks-title">
+            <h2 id="networks-title">Networks</h2>
+            <ul className="content-list network-list">
               {networks.map((network) => (
-                <li key={network.name} className="panel-item panel-item--network">
+                <li key={network.name} className="content-item network-item">
                   <div className="network-summary-item">
                     <span className="network-logo">
                       <Image
@@ -159,7 +158,7 @@ export default function Home() {
                 </li>
               ))}
             </ul>
-          </fieldset>
+          </section>
         </div>
       </main>
 


### PR DESCRIPTION
Update hero messaging and refactor page layout and styling for clearer copy and improved responsive layout.

- Rewrite BorrowCurrencyHero copy to emphasize USYC, staked crypto, Arc and L1 rails; remove the supported-currencies pill list.
- Replace legacy panel/fieldset structure with semantic sections (hero-section, content-section) and rename panel-related classes to content-* and network-*.
- Adjust global CSS: spacing, typography, grid layout, borders, and responsive sizing (hero, headings, lists, content items).
- Update page content: add "L1 tokens" to borrow currencies, simplify step titles/descriptions, and clarify network descriptions.
- Update app metadata (title and description) to reflect vault-backed liquidity across Arc and supported L1 chains.

These changes improve semantics, readability, and responsive presentation of the landing page.